### PR TITLE
update dependencies versions

### DIFF
--- a/email_list_field.gemspec
+++ b/email_list_field.gemspec
@@ -28,12 +28,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'rails', '>= 3.2', '<= 7.1.0'
+  spec.add_runtime_dependency 'rails', '>= 3.2', '< 7.3'
   spec.add_runtime_dependency 'taggle', '0.1.3'
   spec.add_runtime_dependency 'jquery-rails', '~> 4.6.0'
   spec.add_runtime_dependency 'jquery-ui-rails', '~> 6.0.1'
 
-  spec.add_development_dependency "bundler", "~> 2.2.33"
+  spec.add_development_dependency "bundler", "~> 2.4.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.12.0"
 end

--- a/lib/email_list_field/version.rb
+++ b/lib/email_list_field/version.rb
@@ -1,3 +1,3 @@
 module EmailListField
-  VERSION = "1.3.4"
+  VERSION = "1.4.0"
 end


### PR DESCRIPTION
Apenas atualiza a versão das dependências. Todos os testes passaram localmente.

A ideia é permitir versões até 7.2.x.x.